### PR TITLE
feat(clipper): pass cookie param to youtube_dl

### DIFF
--- a/src/clipper/argparser.py
+++ b/src/clipper/argparser.py
@@ -692,11 +692,12 @@ def getArgParser(clipper_paths: ClipperPaths) -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-      "--cookies",
-      "-c",
-      dest="cookies",
+      "--cookiefile",
+      "-cf",
+      dest="cookiefile",
       default="",
-      help="Specify the path to a cookies file to be used by youtube_dl.",
+      help="Specify the path to a Netscape formatted cookies file to be used by youtube_dl. Use this option when sign "
+           "in is required by the video platform.",
     )
     return parser
 

--- a/src/clipper/argparser.py
+++ b/src/clipper/argparser.py
@@ -690,6 +690,14 @@ def getArgParser(clipper_paths: ClipperPaths) -> argparse.ArgumentParser:
         default="yt_dlp",
         help="Choose a youtube_dl alternative for downloading videos.",
     )
+
+    parser.add_argument(
+      "--cookies",
+      "-c",
+      dest="cookies",
+      default="",
+      help="Specify the path to a cookies file to be used by youtube_dl.",
+    )
     return parser
 
 

--- a/src/clipper/argparser.py
+++ b/src/clipper/argparser.py
@@ -697,7 +697,8 @@ def getArgParser(clipper_paths: ClipperPaths) -> argparse.ArgumentParser:
       dest="cookiefile",
       default="",
       help="Specify the path to a Netscape formatted cookies file to be used by youtube_dl. Use this option when sign "
-           "in is required by the video platform.",
+           "in is required by the video platform. On how to obtain the cookies file, "
+           "see https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp",
     )
     return parser
 

--- a/src/clipper/ffmpeg_filter.py
+++ b/src/clipper/ffmpeg_filter.py
@@ -34,6 +34,9 @@ def getSubs(cs: ClipperState) -> None:
         "cachedir": False,
     }
 
+    if settings["cookiefile"] != "":
+        ydl_opts["cookiefile"] = settings["cookiefile"]
+
     importlib.reload(ytdl_importer.youtube_dl)
     with ytdl_importer.youtube_dl.YoutubeDL(ydl_opts) as ydl:
         ydl.download([settings["videoPageURL"]])

--- a/src/clipper/ytc_settings.py
+++ b/src/clipper/ytc_settings.py
@@ -223,8 +223,8 @@ def _getVideoInfo(cs: ClipperState) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         "youtube_include_dash_manifest": False,
     }
 
-    if settings["cookies"] != "":
-        ydl_opts["cookiefile"] = settings["cookies"]
+    if settings["cookiefile"] != "":
+        ydl_opts["cookiefile"] = settings["cookiefile"]
 
     if settings["username"] != "" or settings["password"] != "":
         ydl_opts["username"] = settings["username"]

--- a/src/clipper/ytc_settings.py
+++ b/src/clipper/ytc_settings.py
@@ -290,7 +290,7 @@ def getMoreVideoInfo(cs: ClipperState, videoInfo: Dict, audioInfo: Dict) -> None
         settings["videoType"] = "local_video"
         probedSettings = ffprobeVideoProperties(cs, settings["inputVideo"])
     else:
-        probedSettings = ffprobeVideoProperties(cs, settings["videoDownloadURL"]) if not settings['cookies'] else None
+        probedSettings = ffprobeVideoProperties(cs, settings["videoDownloadURL"])
 
     settings.update(videoInfo)
     if probedSettings is not None:

--- a/src/clipper/ytc_settings.py
+++ b/src/clipper/ytc_settings.py
@@ -223,6 +223,9 @@ def _getVideoInfo(cs: ClipperState) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         "youtube_include_dash_manifest": False,
     }
 
+    if settings["cookies"] != "":
+        ydl_opts["cookiefile"] = settings["cookies"]
+
     if settings["username"] != "" or settings["password"] != "":
         ydl_opts["username"] = settings["username"]
         ydl_opts["password"] = settings["password"]
@@ -287,7 +290,7 @@ def getMoreVideoInfo(cs: ClipperState, videoInfo: Dict, audioInfo: Dict) -> None
         settings["videoType"] = "local_video"
         probedSettings = ffprobeVideoProperties(cs, settings["inputVideo"])
     else:
-        probedSettings = ffprobeVideoProperties(cs, settings["videoDownloadURL"])
+        probedSettings = ffprobeVideoProperties(cs, settings["videoDownloadURL"]) if not settings['cookies'] else None
 
     settings.update(videoInfo)
     if probedSettings is not None:


### PR DESCRIPTION
<!--
Thank you for opening a PR.

Please ensure your PR follows these guidelines:

- [ ] Reasonably consistent and short commit messages.
- [ ] Issue references where necessary.
- [ ] Logically chunked commits.
-->

**What does this PR contribute?**:
Add an argument to specify a path to cookie file to be passed into youtube_dl (cookiefile argument)

**Which issues does this PR address?**:
Recently Youtube has been cracking down on automated activity which has resulted in many non-residential IPs being blocked with the following error: "Sign in to confirm you’re not a bot". Discussion in yt-dlp repo can be located here https://github.com/yt-dlp/yt-dlp/issues/10128.

While it is pointed out there that passing cookies in this case can be dangerous because of the potential account ban this is the only reliable way (that I have found) to make it work while using VPN.

<!--
Commit messages formatted as `fixes/closes/resolves #<issue_number>`, will automatically close relevant issues when the PR is merged.)
-->

**Notes**:
Implementation caveats:
* It currently skips ffprobe invocation if cookies are passed because ffprobe has no native support for it and unless a custom cookie parser is implemented to pass them via headers I see no way to do it;
* I also have a version that passes cookies to ffmpeg via `-cookies` param when streaming but it doesn't seem to be necessary.