### PR TITLE
feat(clipper): add h264_nvenc support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -477,6 +477,8 @@ The Vulkan technology is supported by Linux and Windows across most modern GPUs 
 
 yt_clipper supports `h264_vulkan` for Vulkan-based hardware-accleration of h264 encoding.
 
+yt_clipper also supports `h264_nvenc` for NVIDIA GPU hardware-accelerated h264 encoding. This requires an NVIDIA GPU with NVENC support (most modern NVIDIA GPUs) and ffmpeg compiled with nvenc support. It is supported on Windows and Linux.
+
 ## Articles on CRF and vp9 Encoding
 
 1. [Basic crf guide](https://slhck.info/video/2017/02/24/crf-guide.html)

--- a/src/clipper/argparser.py
+++ b/src/clipper/argparser.py
@@ -547,7 +547,7 @@ def getArgParser() -> argparse.ArgumentParser:
         "-vc",
         dest="videoCodec",
         default="vp9",
-        choices=["vp9", "vp8", "h264", "h264_vulkan"],
+        choices=["vp9", "vp8", "h264", "h264_vulkan", "h264_nvenc"],
         help=" ".join(
             [
                 "Select a video codec for video encoding."
@@ -557,6 +557,8 @@ def getArgParser() -> argparse.ArgumentParser:
                 "h264 was added more recently and is not as well tested as vp9.",
                 "h264_vulkan uses hardware acceleration (typically a discrete GPU) for faster encodes at the cost of some quality.",
                 "h264_vulkan uses the Vulkan technology which is supported on Linux and Windows across most modern GPUs (AMD/NVIDIA/Intel). MacOS and iOS are not yet supported. Requires ffmpeg >= 7.1.",
+                "h264_nvenc uses NVIDIA GPU hardware acceleration for faster encodes at the cost of some quality.",
+                "h264_nvenc is supported on Windows and Linux with NVIDIA GPUs that have NVENC support (most modern NVIDIA GPUs). Requires ffmpeg with nvenc support.",
                 "If you have issues with hardware acceleration, ensure you have the latest drivers.",
             ],
         ),

--- a/src/clipper/clip_maker.py
+++ b/src/clipper/clip_maker.py
@@ -605,8 +605,8 @@ def makeClip(cs: ClipperState, markerPairIndex: int) -> Optional[Dict[str, Any]]
             vidstabtransformFilter += loop_filter
 
         if isHardwareAcceleratedVideoCodec(mps["videoCodec"]):
-            vidstabdetectFilter = wrapVideoFilterForHardwareAcceleration(vidstabdetectFilter)
-            vidstabtransformFilter = wrapVideoFilterForHardwareAcceleration(vidstabtransformFilter)
+            vidstabdetectFilter = wrapVideoFilterForHardwareAcceleration(mps["videoCodec"], vidstabdetectFilter)
+            vidstabtransformFilter = wrapVideoFilterForHardwareAcceleration(mps["videoCodec"], vidstabtransformFilter)
 
         if len(video_filter) > MAX_VFILTER_SIZE:
             logger.info(f"Video filter is larger than {MAX_VFILTER_SIZE} characters.")
@@ -644,10 +644,7 @@ def makeClip(cs: ClipperState, markerPairIndex: int) -> Optional[Dict[str, Any]]
             video_filter += loop_filter
 
         if isHardwareAcceleratedVideoCodec(mps["videoCodec"]):
-            # Only wrap with hardware acceleration for Vulkan codecs
-            # NVENC codecs handle format conversion internally
-            if mps["videoCodec"] == "h264_vulkan":
-                video_filter = wrapVideoFilterForHardwareAcceleration(video_filter)
+            video_filter = wrapVideoFilterForHardwareAcceleration(mps["videoCodec"], video_filter)
 
         if len(video_filter) > MAX_VFILTER_SIZE:
             logger.info(f"Video filter is larger than {MAX_VFILTER_SIZE} characters.")

--- a/src/clipper/clip_maker.py
+++ b/src/clipper/clip_maker.py
@@ -605,8 +605,12 @@ def makeClip(cs: ClipperState, markerPairIndex: int) -> Optional[Dict[str, Any]]
             vidstabtransformFilter += loop_filter
 
         if isHardwareAcceleratedVideoCodec(mps["videoCodec"]):
-            vidstabdetectFilter = wrapVideoFilterForHardwareAcceleration(mps["videoCodec"], vidstabdetectFilter)
-            vidstabtransformFilter = wrapVideoFilterForHardwareAcceleration(mps["videoCodec"], vidstabtransformFilter)
+            vidstabdetectFilter = wrapVideoFilterForHardwareAcceleration(
+                mps["videoCodec"], vidstabdetectFilter
+            )
+            vidstabtransformFilter = wrapVideoFilterForHardwareAcceleration(
+                mps["videoCodec"], vidstabtransformFilter
+            )
 
         if len(video_filter) > MAX_VFILTER_SIZE:
             logger.info(f"Video filter is larger than {MAX_VFILTER_SIZE} characters.")

--- a/src/clipper/clip_maker.py
+++ b/src/clipper/clip_maker.py
@@ -606,10 +606,12 @@ def makeClip(cs: ClipperState, markerPairIndex: int) -> Optional[Dict[str, Any]]
 
         if isHardwareAcceleratedVideoCodec(mps["videoCodec"]):
             vidstabdetectFilter = wrapVideoFilterForHardwareAcceleration(
-                mps["videoCodec"], vidstabdetectFilter
+                mps["videoCodec"],
+                vidstabdetectFilter,
             )
             vidstabtransformFilter = wrapVideoFilterForHardwareAcceleration(
-                mps["videoCodec"], vidstabtransformFilter
+                mps["videoCodec"],
+                vidstabtransformFilter,
             )
 
         if len(video_filter) > MAX_VFILTER_SIZE:

--- a/src/clipper/clip_maker.py
+++ b/src/clipper/clip_maker.py
@@ -644,7 +644,10 @@ def makeClip(cs: ClipperState, markerPairIndex: int) -> Optional[Dict[str, Any]]
             video_filter += loop_filter
 
         if isHardwareAcceleratedVideoCodec(mps["videoCodec"]):
-            video_filter = wrapVideoFilterForHardwareAcceleration(video_filter)
+            # Only wrap with hardware acceleration for Vulkan codecs
+            # NVENC codecs handle format conversion internally
+            if mps["videoCodec"] == "h264_vulkan":
+                video_filter = wrapVideoFilterForHardwareAcceleration(video_filter)
 
         if len(video_filter) > MAX_VFILTER_SIZE:
             logger.info(f"Video filter is larger than {MAX_VFILTER_SIZE} characters.")

--- a/src/clipper/ffmpeg_codec.py
+++ b/src/clipper/ffmpeg_codec.py
@@ -236,7 +236,7 @@ def getFfmpegVideoCodecH264Nvenc(
     dynamic_range_args = sdr_args
     if mps["enableHDR"]:
         dynamic_range_args = hdr_args
-    
+
     video_codec_args = " ".join(
         (
             f"-c:v h264_nvenc",

--- a/src/clipper/ffmpeg_codec.py
+++ b/src/clipper/ffmpeg_codec.py
@@ -230,6 +230,7 @@ def getFfmpegVideoCodecH264Nvenc(
         fps_arg = "-fps_mode vfr"
 
     sdr_args = "-pix_fmt cuda"
+    # h264_nvenc does not support 10-bit HDR output
     hdr_args = "-pix_fmt cuda -color_primaries bt2020 -color_trc smpte2084 -colorspace bt2020nc"
 
     dynamic_range_args = sdr_args

--- a/src/clipper/ffmpeg_filter.py
+++ b/src/clipper/ffmpeg_filter.py
@@ -576,7 +576,6 @@ def wrapVideoFilterForHardwareAcceleration(videoCodec: str, video_filter: str) -
     if 'nvenc' in videoCodec:
         # Frame data is already in VRAM coming from the decoder, we use it to quickly convert to 4:4:4 yuv format to avoid chroma subsampling artifacts
         # After the filter chain, we upload the frame data back to VRAM unless the user supplied a custom filter that already does that
-        # TODO: support HDR pix_fmt
         video_filter_suffix = ",hwupload_cuda" if "hwupload" not in video_filter else ""
         return f"scale_cuda=format=yuv444p,hwdownload,format=yuv444p,{video_filter}{video_filter_suffix}"
     

--- a/src/clipper/ffmpeg_filter.py
+++ b/src/clipper/ffmpeg_filter.py
@@ -573,12 +573,12 @@ def videoStabilizationGammaFixFilter(filter_to_wrap: str) -> str:
 
 
 def wrapVideoFilterForHardwareAcceleration(videoCodec: str, video_filter: str) -> str:
-    if 'nvenc' in videoCodec:
+    if "nvenc" in videoCodec:
         # Frame data is already in VRAM coming from the decoder, we use it to quickly convert to 4:4:4 yuv format to avoid chroma subsampling artifacts
         # After the filter chain, we upload the frame data back to VRAM unless the user supplied a custom filter that already does that
         video_filter_suffix = ",hwupload_cuda" if "hwupload" not in video_filter else ""
         return f"scale_cuda=format=yuv444p,hwdownload,format=yuv444p,{video_filter}{video_filter_suffix}"
-    
+
     return f"format=nv12,hwupload,hwdownload,format=nv12,{video_filter},format=nv12,hwupload"
 
 

--- a/src/clipper/ffmpeg_filter.py
+++ b/src/clipper/ffmpeg_filter.py
@@ -572,8 +572,15 @@ def videoStabilizationGammaFixFilter(filter_to_wrap: str) -> str:
     return wrapped_filter
 
 
-def wrapVideoFilterForHardwareAcceleration(video_filter: str) -> str:
-    return f"hwdownload,format=nv12,{video_filter},format=nv12,hwupload"
+def wrapVideoFilterForHardwareAcceleration(videoCodec: str, video_filter: str) -> str:
+    if 'nvenc' in videoCodec:
+        # Frame data is already in VRAM coming from the decoder, we use it to quickly convert to 4:4:4 yuv format to avoid chroma subsampling artifacts
+        # After the filter chain, we upload the frame data back to VRAM unless the user supplied a custom filter that already does that
+        # TODO: support HDR pix_fmt
+        video_filter_suffix = ",hwupload_cuda" if "hwupload" not in video_filter else ""
+        return f"scale_cuda=format=yuv444p,hwdownload,format=yuv444p,{video_filter}{video_filter_suffix}"
+    
+    return f"format=nv12,hwupload,hwdownload,format=nv12,{video_filter},format=nv12,hwupload"
 
 
 def isHardwareAcceleratedVideoCodec(codec: str) -> bool:

--- a/src/clipper/ffmpeg_filter.py
+++ b/src/clipper/ffmpeg_filter.py
@@ -575,9 +575,7 @@ def videoStabilizationGammaFixFilter(filter_to_wrap: str) -> str:
 def wrapVideoFilterForHardwareAcceleration(videoCodec: str, video_filter: str) -> str:
     if "nvenc" in videoCodec:
         # Frame data is already in VRAM coming from the decoder, we use it to quickly convert to 4:4:4 yuv format to avoid chroma subsampling artifacts
-        # After the filter chain, we upload the frame data back to VRAM unless the user supplied a custom filter that already does that
-        video_filter_suffix = ",hwupload_cuda" if "hwupload" not in video_filter else ""
-        return f"scale_cuda=format=yuv444p,hwdownload,format=yuv444p,{video_filter}{video_filter_suffix}"
+        return f"scale_cuda=format=yuv444p,hwdownload,format=yuv444p,{video_filter},hwupload_cuda"
 
     return f"format=nv12,hwupload,hwdownload,format=nv12,{video_filter},format=nv12,hwupload"
 

--- a/src/clipper/ffmpeg_filter.py
+++ b/src/clipper/ffmpeg_filter.py
@@ -573,7 +573,7 @@ def videoStabilizationGammaFixFilter(filter_to_wrap: str) -> str:
 
 
 def wrapVideoFilterForHardwareAcceleration(video_filter: str) -> str:
-    return f"format=nv12,hwupload,hwdownload,format=nv12,{video_filter},format=nv12,hwupload"
+    return f"hwdownload,format=nv12,{video_filter},format=nv12,hwupload"
 
 
 def isHardwareAcceleratedVideoCodec(codec: str) -> bool:

--- a/src/clipper/tests/test_e2e.py
+++ b/src/clipper/tests/test_e2e.py
@@ -129,3 +129,32 @@ def test_make_clip_with_local_input_video(
     assert "error" not in out
     assert "ERROR" not in out
     print(out, err)
+
+
+@pytest.mark.slow
+def test_make_clip_nvenc_with_local_input_video(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    with monkeypatch.context() as m:
+        m.setattr(
+            sys,
+            "argv",
+            [
+                "yt_clipper.py",
+                "--markers-json",
+                f'{this_dir / "testdata" / "test-with-dynamic.json"}',
+                "--input-video",
+                f'{this_dir / "testdata" / "test-with-dynamic.mp4"}',
+                "--overwrite",
+                "--video-codec h264_nvenc",
+            ],
+        )
+        main()
+    out, err = capsys.readouterr()
+    # assert no warnings from a yt-dlp extractor
+    assert "WARNING: [" not in out
+    # assert no errors
+    assert "error" not in out
+    assert "ERROR" not in out
+    print(out, err)


### PR DESCRIPTION
This pull request adds support for the `h264_nvenc` codec, enabling NVIDIA GPU hardware acceleration for h264 encoding. The changes include updates to the codec selection, hardware acceleration logic, ffmpeg arguments, and new tests to ensure functionality.

### Codec Support Enhancements:

* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R480-R481): Updated documentation to include `h264_nvenc` as a supported codec for NVIDIA GPU hardware-accelerated h264 encoding, specifying requirements like NVENC support and ffmpeg configuration.
* [`src/clipper/argparser.py`](diffhunk://#diff-de15e5146304028e8fed41a0bc1f6947d15eade88f4c78154417afbdeca6bcefL550-R550): Added `h264_nvenc` to the list of video codec choices and updated the help description to explain its functionality and requirements. [[1]](diffhunk://#diff-de15e5146304028e8fed41a0bc1f6947d15eade88f4c78154417afbdeca6bcefL550-R550) [[2]](diffhunk://#diff-de15e5146304028e8fed41a0bc1f6947d15eade88f4c78154417afbdeca6bcefR560-R561)

### Hardware Acceleration Updates:

* [`src/clipper/clip_maker.py`](diffhunk://#diff-2cbea857fc4f6ef9b7cbdc3efd2f47dc723ee9f3ac62cd9984b8b0a007bd32ceL608-R615): Modified `wrapVideoFilterForHardwareAcceleration` calls to include `videoCodec` as a parameter, enabling codec-specific hardware acceleration logic. [[1]](diffhunk://#diff-2cbea857fc4f6ef9b7cbdc3efd2f47dc723ee9f3ac62cd9984b8b0a007bd32ceL608-R615) [[2]](diffhunk://#diff-2cbea857fc4f6ef9b7cbdc3efd2f47dc723ee9f3ac62cd9984b8b0a007bd32ceL647-R653)
* [`src/clipper/ffmpeg_filter.py`](diffhunk://#diff-78c613ddd915b4ee01d65546a9611c2d2c3d84a35f833ea0057c8a5a9e742b36L575-R579): Updated `wrapVideoFilterForHardwareAcceleration` to handle `nvenc` codecs, optimizing video filter wrapping for NVIDIA GPUs.

### FFmpeg Integration:

* [`src/clipper/ffmpeg_codec.py`](diffhunk://#diff-645ddad17bec32befd23343b6fe899b673d869d0014e49151fdec7a1ae8d18f6R32-R34): Added a new function `getFfmpegVideoCodecH264Nvenc` to define ffmpeg arguments specific to `h264_nvenc`. [[1]](diffhunk://#diff-645ddad17bec32befd23343b6fe899b673d869d0014e49151fdec7a1ae8d18f6R32-R34) [[2]](diffhunk://#diff-645ddad17bec32befd23343b6fe899b673d869d0014e49151fdec7a1ae8d18f6R213-R266)

### Testing:

* [`src/clipper/tests/test_e2e.py`](diffhunk://#diff-1804c27c3595bf10fde4cc6c1e23a76e6112bf383b159449cebbbba4f33070c5R132-R160): Added an end-to-end test for `h264_nvenc` encoding.
