### PR TITLE
fix(clipper): use correct path to vidstab transform filter file

### DIFF
--- a/src/clipper/clip_maker.py
+++ b/src/clipper/clip_maker.py
@@ -627,7 +627,7 @@ def makeClip(cs: ClipperState, markerPairIndex: int) -> Optional[Dict[str, Any]]
             with open(filterPathPass2, "w", encoding="utf-8") as f:
                 f.write(vidstabtransformFilter)
             ffmpegVidstabdetect = ffmpegCommand + f' -filter_script:v "{filterPathPass1}" '
-            ffmpegVidstabtransform = ffmpegCommand + f' -filter_script:v "{filterPathPass1}" '
+            ffmpegVidstabtransform = ffmpegCommand + f' -filter_script:v "{filterPathPass2}" '
         else:
             ffmpegVidstabdetect = ffmpegCommand + f'-vf "{vidstabdetectFilter}" '
             ffmpegVidstabtransform = ffmpegCommand + f'-vf "{vidstabtransformFilter}" '


### PR DESCRIPTION
This pull request includes a small but critical fix in the `makeClip` function within `src/clipper/clip_maker.py`. The change ensures the correct filter script is used for video stabilization.

* [`src/clipper/clip_maker.py`](diffhunk://#diff-2cbea857fc4f6ef9b7cbdc3efd2f47dc723ee9f3ac62cd9984b8b0a007bd32ceL630-R630): Updated `ffmpegVidstabtransform` to use `filterPathPass2` instead of `filterPathPass1`, aligning it with the intended stabilization process.
